### PR TITLE
Correction on installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ FCMPlugin.hasPermission(function(doesIt){
 ## Installation
 Make sure you have ‘google-services.json’ for Android or  ‘GoogleService-Info.plist’ for iOS in your Cordova project root folder. You don´t need to configure anything else in order to have push notification working for both platforms, everything is magic.
 ```Bash
-cordova plugin add cordova-plugin-fcm-with-dependecy-updated
+cordova plugin add hrs-cordova-plugin-fcm-with-dependecy-updated
 ```
 
 ### Firebase configuration files


### PR DESCRIPTION
Correction on installation command. Actually the command `cordova plugin add cordova-plugin-fcm-with-dependecy-updated` installs another plugin.